### PR TITLE
Comment on escaping dollar sign in PASS env var in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ services:
       - /dev/net/tun
     environment:
       - USER=user@email.com
-      - PASS='pas$word'
+      - PASS=pas$$word # You must substitute $$ for a literal dollar sign
       - COUNTRY=United_States
       - PROTOCOL=UDP
       - CATEGORY=P2P


### PR DESCRIPTION
Any form of quoting will not escape $ signs in a docker-compose. You must escape them using $$ as per https://docs.docker.com/compose/compose-file/#variable-substitution.