### PR TITLE
Allow connections to specific nordvpn host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN apk --no-cache --no-progress upgrade && \
 ENV NET_IFACE=eth0
 
 VOLUME ["/vpn"]
-ENTRYPOINT ["/sbin/tini", "--", "/usr/bin/nordVpn.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/bin/nordVpn.sh", ">", "lib"]
 COPY nordVpn.sh /usr/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN apk --no-cache --no-progress upgrade && \
 ENV NET_IFACE=eth0
 
 VOLUME ["/vpn"]
-ENTRYPOINT ["/sbin/tini", "--", "/usr/bin/nordVpn.sh", ">", "lib"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/bin/nordVpn.sh"]
 COPY nordVpn.sh /usr/bin

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ This container was designed to be started first to provide a connection to other
                 -e COUNTRY=country -e CATEGORY=category \
                 -e PROTOCOL=protocol -d bubuntux/nordvpn
 
+Connecting to a specific host
+
+    docker run -ti --cap-add=NET_ADMIN --device /dev/net/tun --name vpn \
+                -e USER=user@email.com -e PASS='pas$word' \
+                -e HOSTNAME=au416.nordvpn.com \
+                -d bubuntux/nordvpn
+
 Once it's up other containers can be started using it's network connection:
 
     docker run -it --net=container:vpn -d some/docker-container
@@ -92,6 +99,7 @@ By the fault the container will try to reconnect to the same server when disconn
  * `USER`     - User for NordVPN account.
  * `PASS`     - Password for NordVPN account, surrounding the password in single quotes will prevent issues with special characters such as `$`.
  * `COUNTRY`  - Use servers from an specific country (IE United_States, Australia, NZ, Hong Kong, MX, [full list](https://nordvpn.com/servers/)).  
+ * `HOSTNAME` - Use a specific NordVPN host. Providing this will ignore `COUNTRY`, `CATEGORY` and `PROTOCOL` settings
  * `CATEGORY` - Use servers from an specific category (IE Double_VPN, Standard VPN servers). Allowed categories are:
    * `Standard VPN servers` Get connected to ultra-fast VPN servers anywhere around the globe to change your IP address and protect your browsing activities.
    * `P2P` Choose from hundreds of servers optimized for P2P sharing. NordVPN has no bandwidth limits and doesn’t log any of your activity.

--- a/nordVpn.sh
+++ b/nordVpn.sh
@@ -125,19 +125,26 @@ select_hostname() {
           filters hostname
 
     white_list ${nordvpn_api}
-    echo "Selecting the best server..." > /dev/stderr
-    filters+="$(country_filter ${nordvpn_api})"
-    filters+="$(group_filter ${nordvpn_api})"
-    filters+="$(technology_filter )"
 
-    hostname=`curl -s "${nordvpn_api}/v1/servers/recommendations?${filters}limit=1" | jq -r ".[].hostname"`
-    if [[ -z ${hostname} ]]; then
-        echo "Unable to find a server with the specified parameters, using any recommended server" > /dev/stderr
-        hostname=`curl -s "${nordvpn_api}/v1/servers/recommendations?limit=1" | jq -r ".[].hostname"`
+    if [[ -z $HOSTNAME ]]; then
+        echo "Selecting the best server..." > /dev/stderr
+        filters+="$(country_filter ${nordvpn_api})"
+        filters+="$(group_filter ${nordvpn_api})"
+        filters+="$(technology_filter )"
+
+        hostname=`curl -s "${nordvpn_api}/v1/servers/recommendations?${filters}limit=1" | jq -r ".[].hostname"`
+        if [[ -z ${hostname} ]]; then
+            echo "Unable to find a server with the specified parameters, using any recommended server" > /dev/stderr
+            hostname=`curl -s "${nordvpn_api}/v1/servers/recommendations?limit=1" | jq -r ".[].hostname"`
+        fi
+
+        echo "Best server : ${hostname}" > /dev/stderr
+        echo ${hostname}
+    else
+        echo "Using supplied hostname '$HOSTNAME'..." > /dev/stderr
+        echo ${HOSTNAME}
     fi
 
-    echo "Best server : ${hostname}" > /dev/stderr
-    echo ${hostname}
 }
 
 select_config_file() {


### PR DESCRIPTION
Provides the ability to connect to  a specific vpn host. This is particularly useful when the same IP address needs to be maintained rather than establishing a connection to a new host each time.

The `$HOSTNAME` env var is used for this which will override the other settings that are used to search for a node (ie: `COUNTRY`, `CATEGORY` and `PROTOCOL`) if it is set.

Testing this out with the following run command:

```
    docker run -ti --cap-add=NET_ADMIN --device /dev/net/tun --name vpn \
                -e USER=user@email.com -e PASS='pas$word' \
                -e HOSTNAME=au416.nordvpn.com \
                -d bubuntux/nordvpn
```

yielded the following log output and expected result

```
Staring firewall...
Whitelisting downloads.nordcdn.com...
Downloading config files...
Whitelisting api.nordvpn.com...
Using supplied hostname 'au416.nordvpn.com'...
Using config file /vpn/ovpn/au416.nordvpn.com.udp.ovpn...
Connecting ...
+ sg vpn -c 'openvpn --config /vpn/ovpn/au416.nordvpn.com.udp.ovpn --auth-user-pass /vpn/auth --auth-nocache                                 --script-security 2 --up /etc/openvpn/up.sh --down /etc/openvpn/down.sh                                 '
Sat Oct 26 02:06:37 2019 OpenVPN 2.4.7 x86_64-alpine-linux-musl [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [MH/PKTINFO] [AEAD] built on May  5 2019
Sat Oct 26 02:06:37 2019 library versions: OpenSSL 1.1.1d  10 Sep 2019, LZO 2.10
Sat Oct 26 02:06:37 2019 WARNING: --ping should normally be used with --ping-restart or --ping-exit
Sat Oct 26 02:06:37 2019 NOTE: the current --script-security setting may allow this configuration to call user-defined scripts
Sat Oct 26 02:06:37 2019 Outgoing Control Channel Authentication: Using 512 bit message hash 'SHA512' for HMAC authentication
Sat Oct 26 02:06:37 2019 Incoming Control Channel Authentication: Using 512 bit message hash 'SHA512' for HMAC authentication
Sat Oct 26 02:06:37 2019 TCP/UDP: Preserving recently used remote address: [AF_INET]103.137.12.157:1194
Sat Oct 26 02:06:37 2019 Socket Buffers: R=[212992->212992] S=[212992->212992]
Sat Oct 26 02:06:37 2019 UDP link local: (not bound)
Sat Oct 26 02:06:37 2019 UDP link remote: [AF_INET]103.137.12.157:1194
Sat Oct 26 02:06:37 2019 TLS: Initial packet from [AF_INET]103.137.12.157:1194, sid=eee6f8cc 48f304b5
Sat Oct 26 02:06:37 2019 VERIFY OK: depth=2, C=PA, O=NordVPN, CN=NordVPN Root CA
Sat Oct 26 02:06:37 2019 VERIFY OK: depth=1, C=PA, O=NordVPN, CN=NordVPN CA3
Sat Oct 26 02:06:37 2019 VERIFY KU OK
Sat Oct 26 02:06:37 2019 Validating certificate extended key usage
Sat Oct 26 02:06:37 2019 ++ Certificate has EKU (str) TLS Web Server Authentication, expects TLS Web Server Authentication
Sat Oct 26 02:06:37 2019 VERIFY EKU OK
Sat Oct 26 02:06:37 2019 VERIFY OK: depth=0, CN=au416.nordvpn.com
Sat Oct 26 02:06:38 2019 Control Channel: TLSv1.2, cipher TLSv1.2 ECDHE-RSA-AES256-GCM-SHA384, 4096 bit RSA
Sat Oct 26 02:06:38 2019 [au416.nordvpn.com] Peer Connection Initiated with [AF_INET]103.137.12.157:1194
Sat Oct 26 02:06:39 2019 SENT CONTROL [au416.nordvpn.com]: 'PUSH_REQUEST' (status=1)
Sat Oct 26 02:06:39 2019 PUSH: Received control message: 'PUSH_REPLY,redirect-gateway def1,dhcp-option DNS 103.86.96.100,dhcp-option DNS 103.86.99.100,sndbuf 524288,rcvbuf 524288,explicit-exit-notify,comp-lzo no,route-gateway 10.8.3.1,topology subnet,ping 60,ping-restart 180,ifconfig 10.8.3.17 255.255.255.0,peer-id 10,cipher AES-256-GCM'
Sat Oct 26 02:06:39 2019 OPTIONS IMPORT: timers and/or timeouts modified
Sat Oct 26 02:06:39 2019 OPTIONS IMPORT: explicit notify parm(s) modified
Sat Oct 26 02:06:39 2019 OPTIONS IMPORT: compression parms modified
Sat Oct 26 02:06:39 2019 OPTIONS IMPORT: --sndbuf/--rcvbuf options modified
Sat Oct 26 02:06:39 2019 Socket Buffers: R=[212992->425984] S=[212992->425984]
Sat Oct 26 02:06:39 2019 OPTIONS IMPORT: --ifconfig/up options modified
Sat Oct 26 02:06:39 2019 OPTIONS IMPORT: route options modified
Sat Oct 26 02:06:39 2019 OPTIONS IMPORT: route-related options modified
Sat Oct 26 02:06:39 2019 OPTIONS IMPORT: --ip-win32 and/or --dhcp-option options modified
Sat Oct 26 02:06:39 2019 OPTIONS IMPORT: peer-id set
Sat Oct 26 02:06:39 2019 OPTIONS IMPORT: adjusting link_mtu to 1657
Sat Oct 26 02:06:39 2019 OPTIONS IMPORT: data channel crypto options modified
Sat Oct 26 02:06:39 2019 Data Channel: using negotiated cipher 'AES-256-GCM'
Sat Oct 26 02:06:39 2019 Outgoing Data Channel: Cipher 'AES-256-GCM' initialized with 256 bit key
Sat Oct 26 02:06:39 2019 Incoming Data Channel: Cipher 'AES-256-GCM' initialized with 256 bit key
Sat Oct 26 02:06:39 2019 ROUTE_GATEWAY 172.17.0.1/255.255.0.0 IFACE=eth0 HWADDR=02:42:ac:11:00:02
Sat Oct 26 02:06:39 2019 TUN/TAP device tun0 opened
Sat Oct 26 02:06:39 2019 TUN/TAP TX queue length set to 100
Sat Oct 26 02:06:39 2019 /sbin/ip link set dev tun0 up mtu 1500
Sat Oct 26 02:06:39 2019 /sbin/ip addr add dev tun0 10.8.3.17/24 broadcast 10.8.3.255
Sat Oct 26 02:06:39 2019 /etc/openvpn/up.sh tun0 1500 1585 10.8.3.17 255.255.255.0 init
Sat Oct 26 02:06:39 2019 /sbin/ip route add 103.137.12.157/32 via 172.17.0.1
Sat Oct 26 02:06:39 2019 /sbin/ip route add 0.0.0.0/1 via 10.8.3.1
Sat Oct 26 02:06:39 2019 /sbin/ip route add 128.0.0.0/1 via 10.8.3.1
Sat Oct 26 02:06:39 2019 Initialization Sequence Completed
```