### PR TITLE
documentation - fix env variable PASS

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ services:
       - "PASS=pas$word"         # Required
       - CONNECT=United_States
       - TECHNOLOGY=NordLynx
-    stdin_open: true
-    tty: true
 
   torrent:
     image: linuxserver/qbittorrent
@@ -130,8 +128,6 @@ services:
       - NETWORK=192.168.1.0/24 
     ports:
       - 8080:8080
-    stdin_open: true
-    tty: true
 
   torrent:
     image: linuxserver/qbittorrent

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ services:
       - "PASS=pas$word"         # Required
       - CONNECT=United_States
       - TECHNOLOGY=NordLynx
+    stdin_open: true
+    tty: true
 
   torrent:
     image: linuxserver/qbittorrent
@@ -128,7 +130,9 @@ services:
       - NETWORK=192.168.1.0/24 
     ports:
       - 8080:8080
-    
+    stdin_open: true
+    tty: true
+
   torrent:
     image: linuxserver/qbittorrent
     network_mode: service:vpn

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ services:
       - /dev/net/tun            # Required
     environment:                # Review https://github.com/bubuntux/nordvpn#environment-variables
       - USER=user@email.com     # Required
-      - PASS='pas$word'         # Required
+      - "PASS=pas$word"         # Required
       - CONNECT=United_States
       - TECHNOLOGY=NordLynx
 
@@ -122,7 +122,7 @@ services:
       - /dev/net/tun            # Required
     environment:                # Review https://github.com/bubuntux/nordvpn#environment-variables
       - USER=user@email.com     # Required
-      - PASS='pas$word'         # Required
+      - "PASS=pas$word"         # Required
       - CONNECT=United_States
       - TECHNOLOGY=NordLynx
       - NETWORK=192.168.1.0/24 


### PR DESCRIPTION
It took me two episodes of Swamp Thing to figure this out.

With the single quote the password works on docker run command line. But in docker compose the single quote is interpreted as part of the password.

To get the invalid password error I had to activate stdin_out and tty but it is not needed to run the container. (That's why you see a second commit and a 3rd which is a revert of this 2nd commit)