### PR TITLE
Wrap sysctl to prevent norvpn client from exiting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN addgroup --system vpn && \
     apt-get update && apt-get install -yqq nordvpn${NORDVPN_VERSION:+=$NORDVPN_VERSION} || sed -i "s/init)/$(ps --no-headers -o comm 1))/" /var/lib/dpkg/info/nordvpn.postinst && \
     update-alternatives --set iptables /usr/sbin/iptables-legacy && \
     update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy && \
+    mv /sbin/sysctl /sbin/sysctl.orig && \
     apt-get install -yqq && apt-get clean && \
     rm -rf \
         ./nordvpn* \
@@ -23,6 +24,7 @@ RUN addgroup --system vpn && \
         /var/tmp/*
 #CROSSRUN [ "cross-build-end" ]
 
-CMD /usr/bin/start_vpn.sh
 COPY start_vpn.sh /usr/bin
+COPY sysctl_wrapper.sh /sbin/sysctl
 
+CMD /usr/bin/start_vpn.sh

--- a/sysctl_wrapper.sh
+++ b/sysctl_wrapper.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ "$1" == "-w"  ]]; then
+    echo $2 | sed 's/=/ = /'
+    exit 0
+else
+    exec /sbin/sysctl.orig $@
+fi


### PR DESCRIPTION
It seems as if norvpn client (3.8.4) is now hard failing on setting `net.ipv6.conf.all.disable_ipv6=1` with a message like:

`[Error] disabling IPv6: sysctl: setting key "net.ipv6.conf.all.disable_ipv6": Read-only file system`

Unfortunately this also happens when net.ipv6.conf.all.disable_ipv6 is already set to 1 with:
`--cap-add=SYS_MODULE --sysctl net.ipv6.conf.all.disable_ipv6=1`

This dumb wrapper gets around that by faking successful writes.

While this works with OpenVPN for me it panics for NordLynx:

```
panic: runtime error: index out of range [1] with length 1

goroutine 263 [running]:
nordvpn/daemon.addWGRules(0x10fb220, 0x17f2fc1, 0xc0030403e0, 0x1, 0x3, 0x0, 0x0, 0x1, 0x1f, 0x1c)
        /builds/nordvpn/apps-source/linux-app/src/daemon/vpn_nordlynx.go:198 +0x71e
nordvpn/daemon.(*NordLynxLib).Start(0xc000199400, 0x2430026, 0xc000822280, 0x18, 0xc0008222a0, 0x18, 0xc000642a20, 0x2c, 0x0, 0x0, ...)
        /builds/nordvpn/apps-source/linux-app/src/daemon/vpn_nordlynx_lib.go:159 +0x136c
created by nordvpn/daemon.connect
        /builds/nordvpn/apps-source/linux-app/src/daemon/rpc.go:417 +0xcff
```

Possibly related issues:
* #103
* #104 