### PR TITLE
Added traceroute to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ HEALTHCHECK --interval=5m --timeout=20s --start-period=1m \
 #CROSSRUN [ "cross-build-start" ]
 RUN addgroup --system vpn && \
     apt-get update && apt-get upgrade -y && \
-    apt-get install -y wget dpkg curl gnupg2 jq && \
+    apt-get install -y wget dpkg curl gnupg2 jq traceroute && \
     wget -nc https://repo.nordvpn.com/deb/nordvpn/debian/pool/main/nordvpn-release_1.0.0_all.deb && dpkg -i nordvpn-release_1.0.0_all.deb && \
     apt-get update && apt-get install -yqq nordvpn${NORDVPN_VERSION:+=$NORDVPN_VERSION} || sed -i "s/init)/$(ps --no-headers -o comm 1))/" /var/lib/dpkg/info/nordvpn.postinst && \
     update-alternatives --set iptables /usr/sbin/iptables-legacy && \


### PR DESCRIPTION
Closes: #110

Added traceroute to the Dockerfile. Built and tested locally.

```
docker run -it nordvpn /bin/sh
# traceroute
Usage:
  traceroute [ -46dFITnreAUDV ] [ -f first_ttl ] [ -g gate,... ] [ -i device ] [ -m max_ttl ] [ -N squeries ] [ -p port ] [ -t tos ] [ -l flow_label ] [ -w MAX,HERE,NEAR ] [ -q nqueries ] [ -s src_addr ] [ -z sendwait ] [ --fwmark=num ] host [ packetlen ]
Options:
...
```