### PR TITLE
Always allow port 53 (DNS) traffic to resolve issues when using custom network

### DIFF
--- a/start_vpn.sh
+++ b/start_vpn.sh
@@ -20,8 +20,8 @@ kill_switch() {
 	iptables -A OUTPUT -o tap+ -j ACCEPT
 	iptables -A OUTPUT -o tun+ -j ACCEPT
 	iptables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT
+	iptables -A OUTPUT -p udp -m udp --dport 51820 -j ACCEPT
 	iptables -A OUTPUT -m owner --gid-owner vpn -j ACCEPT || {
-		iptables  -A OUTPUT -p udp -m udp --dport 51820 -j ACCEPT
 		iptables  -A OUTPUT -p tcp -m tcp --dport 1194  -j ACCEPT
 		iptables  -A OUTPUT -p udp -m udp --dport 1194  -j ACCEPT
 		iptables  -A OUTPUT -p tcp -m tcp --dport 443   -j ACCEPT

--- a/start_vpn.sh
+++ b/start_vpn.sh
@@ -19,8 +19,8 @@ kill_switch() {
 	iptables -A OUTPUT -o lo -j ACCEPT
 	iptables -A OUTPUT -o tap+ -j ACCEPT
 	iptables -A OUTPUT -o tun+ -j ACCEPT
+	iptables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT
 	iptables -A OUTPUT -m owner --gid-owner vpn -j ACCEPT || {
-		iptables  -A OUTPUT -p udp -m udp --dport 53    -j ACCEPT
 		iptables  -A OUTPUT -p udp -m udp --dport 51820 -j ACCEPT
 		iptables  -A OUTPUT -p tcp -m tcp --dport 1194  -j ACCEPT
 		iptables  -A OUTPUT -p udp -m udp --dport 1194  -j ACCEPT
@@ -54,8 +54,8 @@ kill_switch() {
 	ip6tables -A OUTPUT -o lo -j ACCEPT 2>/dev/null
 	ip6tables -A OUTPUT -o tap+ -j ACCEPT 2>/dev/null
 	ip6tables -A OUTPUT -o tun+ -j ACCEPT 2>/dev/null
+	ip6tables -A OUTPUT -p udp -m udp --dport 53 -j ACCEPT 2>/dev/null
 	ip6tables -A OUTPUT -m owner --gid-owner vpn -j ACCEPT 2>/dev/null || {
-		ip6tables -A OUTPUT -p udp -m udp --dport 53    -j ACCEPT 2>/dev/null
 		ip6tables -A OUTPUT -p udp -m udp --dport 51820 -j ACCEPT 2>/dev/null
 		ip6tables -A OUTPUT -p tcp -m tcp --dport 1194  -j ACCEPT 2>/dev/null
 		ip6tables -A OUTPUT -p udp -m udp --dport 1194  -j ACCEPT 2>/dev/null


### PR DESCRIPTION
DNS traffic needs to be allowed from all groups, not just the `vpn` group.

References #91

For some reason I've only been able to get OpenVPN working so far (`TECHNOLOGY=OpenVPN`). WireGuard (`TECHNOLOGY=NordLynx`) "connects" successfully but no data makes it through the tunnel.