### PR TITLE
Update nordvpn version to 3.11.0-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 LABEL maintainer="Julio Gutierrez"
-ARG NORDVPN_VERSION=3.10.0-1
+ARG NORDVPN_VERSION=3.11.0-1
 
 RUN apt-get update -y && \
     apt-get install -y curl iputils-ping tzdata && \


### PR DESCRIPTION
Small bump of the nordvpn version, as there is currently an error:

```
[2021-10-02T13:38:56+00:00] Connecting...
A new version of NordVPN is available! Please update the application.
Connecting to Singapore #460 (sg460.nordvpn.com)
transport is closing
[2021-10-02T13:39:02+00:00] Unable to connect retrying in 1 seconds.
Whoops! Cannot reach System Daemon.
```

This fixes #249.