### PR TITLE
Allow multiple docker networks to be connected

### DIFF
--- a/rootfs/etc/cont-init.d/20-inet
+++ b/rootfs/etc/cont-init.d/20-inet
@@ -5,6 +5,7 @@ if [ -z "$docker_networks" ]; then
   echo "No inet network"
   exit
 fi
+IFS=',' read -ra networks <<< "$docker_networks"
 
 echo "Enabling connection to secure interface and docker network"
 
@@ -13,14 +14,20 @@ iptables -X
 
 iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 iptables -A INPUT -i lo -j ACCEPT
-iptables -A INPUT -i eth0 -s "${docker_networks}" -j ACCEPT
+for net in "${networks[@]}"; do
+  network=($net)
+  iptables -A INPUT -i "${network[0]}" -s "${network[1]}" -j ACCEPT
+done
 
 iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 iptables -A OUTPUT -o lo -j ACCEPT
 iptables -A OUTPUT -o tap+ -j ACCEPT
 iptables -A OUTPUT -o tun+ -j ACCEPT
 iptables -A OUTPUT -o nordlynx+ -j ACCEPT
-iptables -A OUTPUT -o eth0 -d "${docker_networks}" -j ACCEPT
+for net in "${networks[@]}"; do
+  network=($net)
+  iptables -A OUTPUT -o "${network[0]}" -d "${network[1]}" -j ACCEPT
+done
 iptables -A OUTPUT -o eth0 -p udp -m udp --dport 53 -j ACCEPT
 iptables -A OUTPUT -o eth0 -p udp -m udp --dport 51820 -j ACCEPT
 iptables -A OUTPUT -o eth0 -p tcp -m tcp --dport 1194 -j ACCEPT
@@ -29,8 +36,11 @@ iptables -A OUTPUT -o eth0 -p tcp -m tcp --dport 443 -j ACCEPT
 
 iptables -A FORWARD -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 iptables -A FORWARD -i lo -j ACCEPT
-iptables -A FORWARD -i eth0 -d "${docker_networks}" -j ACCEPT
-iptables -A FORWARD -i eth0 -s "${docker_networks}" -j ACCEPT
+for net in "${networks[@]}"; do
+  network=($net)
+  iptables -A FORWARD -i "${network[0]}" -d "${network[1]}" -j ACCEPT
+  iptables -A FORWARD -i "${network[0]}" -s "${network[1]}" -j ACCEPT
+done
 
 iptables -t nat -A POSTROUTING -o tap+ -j MASQUERADE
 iptables -t nat -A POSTROUTING -o tun+ -j MASQUERADE

--- a/rootfs/etc/cont-init.d/20-inet6
+++ b/rootfs/etc/cont-init.d/20-inet6
@@ -5,6 +5,7 @@ if [ -z "$docker_networks" ]; then
   echo "No inet6 network"
   exit
 fi
+IFS=',' read -ra networks <<< "$docker_networks"
 
 echo "Enabling connection to secure interface6 and docker network6"
 
@@ -13,14 +14,20 @@ ip6tables -X
 
 ip6tables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 ip6tables -A INPUT -i lo -j ACCEPT
-ip6tables -A INPUT -i eth0 -s "${docker_networks}" -j ACCEPT
+for net in "${networks[@]}"; do
+  network=($net)
+  ip6tables -A INPUT -i "${network[0]}" -s "${network[1]}" -j ACCEPT
+done
 
 ip6tables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 ip6tables -A OUTPUT -o lo -j ACCEPT
 ip6tables -A OUTPUT -o tap+ -j ACCEPT
 ip6tables -A OUTPUT -o tun+ -j ACCEPT
 ip6tables -A OUTPUT -o nordlynx+ -j ACCEPT
-ip6tables -A OUTPUT -o eth0 -d "${docker_networks}" -j ACCEPT
+for net in "${networks[@]}"; do
+  network=($net)
+  ip6tables -A OUTPUT -o "${network[0]}" -d "${network[1]}" -j ACCEPT
+done
 ip6tables -A OUTPUT -o eth0 -p udp -m udp --dport 53 -j ACCEPT
 ip6tables -A OUTPUT -o eth0 -p udp -m udp --dport 51820 -j ACCEPT
 ip6tables -A OUTPUT -o eth0 -p tcp -m tcp --dport 1194 -j ACCEPT
@@ -29,8 +36,11 @@ ip6tables -A OUTPUT -o eth0 -p tcp -m tcp --dport 443 -j ACCEPT
 
 ip6tables -A FORWARD -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 ip6tables -A FORWARD -i lo -j ACCEPT
-ip6tables -A FORWARD -i eth0 -d "${docker_networks}" -j ACCEPT
-ip6tables -A FORWARD -i eth0 -s "${docker_networks}" -j ACCEPT
+for net in "${networks[@]}"; do
+  network=($net)
+  ip6tables -A FORWARD -i "${network[0]}" -d "${network[1]}" -j ACCEPT
+  ip6tables -A FORWARD -i "${network[0]}" -s "${network[1]}" -j ACCEPT
+done
 
 ip6tables -t nat -A POSTROUTING -o tap+ -j MASQUERADE
 ip6tables -t nat -A POSTROUTING -o tun+ -j MASQUERADE

--- a/rootfs/usr/bin/dockerNetworks
+++ b/rootfs/usr/bin/dockerNetworks
@@ -3,10 +3,12 @@
 docker_networks=$(ip link | awk -F': ' '$0 !~ "lo|wg|tun|tap|^[^0-9]"{print $2;getline}' | cut -d@ -f1 | (
   while read -r interface ; do
     network="$(ip -o addr show dev "$interface" | awk '$3 == "inet" {print $4}')"
-    if [ -z "$result" ]; then
-      result=$network
-    else
-      result=$result,$network
+    if [ ! -z "$network" ]; then
+      if [ -z "$result" ]; then
+        result="$interface $network"
+      else
+        result="$result,$interface $network"
+      fi
     fi
   done
   echo "$result"

--- a/rootfs/usr/bin/dockerNetworks6
+++ b/rootfs/usr/bin/dockerNetworks6
@@ -3,10 +3,12 @@
 docker_networks=$(ip link | awk -F': ' '$0 !~ "lo|wg|tun|tap|^[^0-9]"{print $2;getline}' | cut -d@ -f1 | (
   while read -r interface ; do
     network="$(ip -o addr show dev "$interface" | awk '$3 == "inet6" {print $4; exit}')"
-    if [ -z "$result" ]; then
-      result=$network
-    else
-      result=$result,$network
+    if [ ! -z "$network" ]; then
+      if [ -z "$result" ]; then
+        result="$interface $network"
+      else
+        result="$result,$interface $network"
+      fi
     fi
   done
   echo "$result"

--- a/rootfs/usr/bin/nord_config
+++ b/rootfs/usr/bin/nord_config
@@ -14,7 +14,13 @@ nordvpn set technology ${TECHNOLOGY:-NordLynx}
 [[ -n ${PORT_RANGE} ]] && nordvpn whitelist add ports ${PORT_RANGE}
 
 docker_networks=$(dockerNetworks)
-[[ -n ${docker_networks} ]] && for net in ${docker_networks//[;,]/ }; do nordvpn whitelist add subnet "${net}"; done
+if [[ -n ${docker_networks} ]]; then
+  IFS=',' read -ra networks <<< "$docker_networks"
+  for net in "${networks[@]}"; do
+    network=($net)
+    nordvpn whitelist add subnet "${network[1]}"
+  done
+fi
 [[ -n ${NETWORK} && -z ${NET_LOCAL} ]] && NET_LOCAL=${NETWORK}
 [[ -n ${NET_LOCAL} ]] && for net in ${NET_LOCAL//[;,]/ }; do nordvpn whitelist add subnet "${net}"; done
 


### PR DESCRIPTION
This change fixes the IP tables when more than one docker network is attached to the container. Instead of using `eth0` for every `iptables` command, the correct interface is supplied when adding rules to allow routing within the docker networks. This allows services using the VPN container as a network adapter to communicate with hosts on multiple networks.

I have built and deployed this change to my environment and confirmed the behavior.