### PR TITLE
Update requirements for NET_RAW with fail-safe routing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Official `NordVPN` client in a docker container; it makes routing traffic throug
 # How to use this image
 This container was designed to be started first to provide a connection to other containers (using `--net=container:vpn`, see below *Starting an NordVPN client instance*).
 
-**NOTE**: More than the basic privileges are needed for NordVPN. With docker 1.2 or newer you can use the `--cap-add=NET_ADMIN` option. Earlier versions, or with fig, and you'll have to run it in privileged mode.
+**NOTE**: More than the basic privileges are needed for NordVPN. With Docker 1.2 or newer, Podman, Kubernetes, etc. you can use the `--cap-add=NET_ADMIN,NET_RAW` option. Earlier versions, or with fig, and you'll have to run it in privileged mode.
 
 ## Starting an NordVPN instance
-    docker run -ti --cap-add=NET_ADMIN --name vpn \
+    docker run -ti --cap-add=NET_ADMIN,NET_RAW --name vpn \
                -e USER=user@email.com -e PASS='pas$word' \
                -e TECHNOLOGY=NordLynx -d ghcr.io/bubuntux/nordvpn
 
@@ -34,6 +34,7 @@ services:
     image: ghcr.io/bubuntux/nordvpn
     cap_add:
       - NET_ADMIN               # Required
+      - NET_RAW                 # Required
     environment:                # Review https://github.com/bubuntux/nordvpn#environment-variables
       - USER=user@email.com     # Required
       - "PASS=pas$word"         # Required
@@ -76,6 +77,7 @@ services:
     image: ghcr.io/bubuntux/nordvpn
     cap_add:
       - NET_ADMIN               # Required
+      - NET_RAW                 # Required
     environment:                # Review https://github.com/bubuntux/nordvpn#environment-variables
       - USER=user@email.com     # Required
       - "PASS=pas$word"         # Required
@@ -146,6 +148,7 @@ services:
     container_name: nordvpn
     cap_add:
       - NET_ADMIN               # Required
+      - NET_RAW                 # Required
     environment:                # Review https://github.com/bubuntux/nordvpn#environment-variables
       - USER=user@email.com     # Required
       - "PASS=pas$word"         # Required

--- a/rootfs/usr/bin/nord_login
+++ b/rootfs/usr/bin/nord_login
@@ -1,5 +1,19 @@
 #!/usr/bin/with-contenv bash
 
+if ! iptables -L > /dev/null 2>&1; then
+  echo "FATAL: iptables is not functional. Ensure your container config adds --cap-add=NET_ADMIN,NET_RAW" 1>&2
+  # Null route rather than leaving traffic unprotected.
+  ip route del default
+  ip route del 0.0.0.0/1 > /dev/null 2>&1
+  ip route add default via 127.0.0.1
+  echo "--- Due to errors, routing has been disabled ---" 1>&2
+  # Don't allow execution to proceed as traffic may not be protected. Don't exit either as 
+  # containers that expect to be behind the VPN will route through the normal network.
+  while true; do
+    sleep 3600
+  done
+fi
+
 [[ -z "${PASS}" ]] && [[ -f "${PASSFILE}" ]] && PASS="$(head -n 1 "${PASSFILE}")"
 nordvpn logout > /dev/null
 nordvpn login --legacy --username "${USER}" --password "${PASS}" || {


### PR DESCRIPTION
CRI-O removed NET_RAW from default capabilities starting at version 1.18. This breaks Podman and Kubernetes by causing iptables commands to fail. The iptables failures do not stop the container from running which can lead to traffic bypassing the VPN.

This pull request updates the documentation to include NET_RAW as a requirement. It's enabled by default in Docker so this isn't adding any new capabilities to that runtime, just broadening compatibility across other container runtimes.

It also adds fail-safe null routing (in nord_login) to prevent anything else that is trying to route through this container from sending potentially unprotected traffic when iptables (and therefore the killswitch) fails.