### PR TITLE
run: Fixup nordvpn S6 run file

### DIFF
--- a/rootfs/etc/services.d/nordvpn/run
+++ b/rootfs/etc/services.d/nordvpn/run
@@ -4,4 +4,4 @@ if [[ ! -d /run/nordvpn ]]; then
   mkdir -m 0770 /run/nordvpn
 fi
 
-s6-notifyoncheck /usr/sbin/nordvpnd > /dev/null
+exec s6-notifyoncheck -d /usr/sbin/nordvpnd > /dev/null


### PR DESCRIPTION
  1) Doublefork s6-notifyoncheck as nordvpnd doesn't reap the zombie
  2) exec the chain loading to remove the unnecessary bash parent