### PR TITLE
Add token login

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ services:
 
 * `USER`     - User for NordVPN account.
 * `PASS`     - Password for NordVPN account, surrounding the password in single quotes will prevent issues with special characters such as `$`.
+* `TOKEN`     - Used in place of `USER` and `PASS` for NordVPN account, can be generated in the web portal
 * `PASSFILE` - File from which to get `PASS`, if using [docker secrets](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets) this should be set to `/run/secrets/<secret_name>`. This file should contain just the account password on the first line.
 * `CONNECT`  -  [country]/[server]/[country_code]/[city]/[group] or [country] [city], if none provide you will connect to  the recommended server.
    - Provide a [country] argument to connect to a specific country. For example: Australia , Use `docker run --rm ghcr.io/bubuntux/nordvpn nordvpn countries` to get the list of countries.

--- a/rootfs/usr/bin/nord_login
+++ b/rootfs/usr/bin/nord_login
@@ -16,9 +16,17 @@ fi
 
 [[ -z "${PASS}" ]] && [[ -f "${PASSFILE}" ]] && PASS="$(head -n 1 "${PASSFILE}")"
 nordvpn logout > /dev/null
-nordvpn login --legacy --username "${USER}" --password "${PASS}" || {
-  echo "Invalid Username or password."
-  exit 1
-}
+
+if [[ -n ${TOKEN} ]]; then
+  nordvpn login --token "${TOKEN}" || {
+    echo "Invalid token."
+    exit 1
+  }
+else
+  nordvpn login --legacy --username "${USER}" --password "${PASS}" || {
+    echo "Invalid Username or password."
+    exit 1
+  }
+fi
 
 exit 0


### PR DESCRIPTION
Havent used this repo in a while and just came back to it.

For some reason I was not able to log in with user and password. So this adds token auth. I see you are pushing people over to [nordlynx](https://github.com/bubuntux/nordlynx), but this would still be useful to get the private key