### PR TITLE
Update gh Actions and NordVPN Version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,60 +5,57 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        username: [ ${{ github.repository_owner }} ]
+      include:
+          - name: DockerHub
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
+          - name: GitHub Container Registry
+            registry: ghcr.io
+            password: ${{ secrets.CR_PAT }} #could be replaced with ${{ secrets.GITHUB_TOKEN }} provided by pipeline
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Get branch name
-        id: git
-        run: |
-          NAME=$(echo ${GITHUB_REF} | sed -e "s/.*\///g")
-          echo name=${NAME}  ref=${GITHUB_REF}
-          echo "::set-output name=name::${NAME}"
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: amd64,arm64,arm,386
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Login to ${{ matrix.name }}
+        uses: docker/login-action@v2
         with:
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ matrix.registry }}
+          username: ${{ matrix.username }}
+          password: ${{ matrix.password }}
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1.10.0
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          images: |
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
-          tags: |
-            ${{ github.repository }}:${{ steps.git.outputs.name }}
-            ghcr.io/${{ github.repository }}:${{ steps.git.outputs.name }}
+          tags: ${{ steps.meta.outputs.tags }}
       
-      - name: Push latest
-        uses: docker/build-push-action@v2
-        if: steps.git.outputs.name == 'master'
-        with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
-          tags: |
-            ${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:latest
-
       - name: Update repo description
-        uses: peter-evans/dockerhub-description@v2
-        if: steps.git.outputs.name == 'master'
+        uses: peter-evans/dockerhub-description@v3
+        if: github.ref_name == 'master'
         with:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
             password: ${{ secrets.DOCKERHUB_TOKEN }}
           - name: GitHub Container Registry
             registry: ghcr.io
-            password: ${{ secrets.CR_PAT }} #could be replaced with ${{ secrets.GITHUB_TOKEN }} provided by pipeline
+            password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,15 +5,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        username: [ ${{ github.repository_owner }} ]
-      include:
-          - name: DockerHub
-            password: ${{ secrets.DOCKERHUB_TOKEN }}
-          - name: GitHub Container Registry
-            registry: ghcr.io
-            password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,12 +17,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to ${{ matrix.name }}
+      - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          registry: ${{ matrix.registry }}
-          username: ${{ matrix.username }}
-          password: ${{ matrix.password }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v4
+    - uses: actions/stale@v7
       with:
         stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
         stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/linuxserver/baseimage-ubuntu:bionic
 LABEL maintainer="Julio Gutierrez julio.guti+nordvpn@pm.me"
 
-ARG NORDVPN_VERSION=3.14.1
+ARG NORDVPN_VERSION=3.15.3
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \


### PR DESCRIPTION
Hi,
I noticed that the NordVPN Version is not the latest version - so I wanted to create a PR for updating NordVPN to v3.15.3.
While doing so, I saw the gh action pipeline with older versions of gh actions referenced. I updated them aswell and refactored it using the docker metadata action and using gh context variables.
You don't need the `CR_PAT` secret any longer for this pipeline. GitHub creates a `GITHUB_TOKEN` secret in the pipeline and with permissions: packages:write you can push to your ghcr without any PAT ;)

I tested this pipeline and verified that it works.

Hope it helps :wink: