### PR TITLE
feat: support getting private key by token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="Julio Gutierrez julio.guti+nordvpn@pm.me"
 ARG DEBIAN_FRONTEND=noninteractive
-ARG NORDVPN_VERSION=3.12.4
+ARG NORDVPN_VERSION=3.15.3
 
 COPY get_private_key.sh /usr/bin
 

--- a/get_private_key.sh
+++ b/get_private_key.sh
@@ -10,8 +10,8 @@ fi
 /usr/sbin/nordvpnd > /dev/null &
 sleep 1
 
-nordvpn login --legacy --username "${USER}" --password "${PASS}" || {
-  echo "Invalid Username or password."
+nordvpn login --token "${TOKEN}" || {
+  echo "Invalid token."
   exit 1
 }
 


### PR DESCRIPTION
The old method doesn't seem to work for me and NordVPN are removing the possibility to login via user + password.

Using this change I was able to get the private key that in turn worked perfectly with PRIVATE_KEY in bubuntux/nordlynx image.