### PR TITLE
Fix for 3.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,4 @@ RUN apt-get update -y && \
 
 COPY /rootfs /
 ENV S6_CMD_WAIT_FOR_SERVICES=1
-CMD nord_login
-# CMD nord_login && nord_config && nord_connect && nord_migrate && nord_watch
+CMD nord_login && nord_config && nord_connect && nord_migrate && nord_watch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:bionic
+FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy
 LABEL maintainer="Julio Gutierrez julio.guti+nordvpn@pm.me"
 
-ARG NORDVPN_VERSION=3.15.3
+ARG NORDVPN_VERSION=3.16.1
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
@@ -21,4 +21,5 @@ RUN apt-get update -y && \
 
 COPY /rootfs /
 ENV S6_CMD_WAIT_FOR_SERVICES=1
-CMD nord_login && nord_config && nord_connect && nord_migrate && nord_watch
+CMD nord_login
+# CMD nord_login && nord_config && nord_connect && nord_migrate && nord_watch

--- a/rootfs/etc/fix-attrs.d/nord_utils
+++ b/rootfs/etc/fix-attrs.d/nord_utils
@@ -3,3 +3,4 @@
 /usr/bin/nord_login false root:root 0755 0755
 /usr/bin/nord_migrate false root:root 0755 0755
 /usr/bin/nord_watch false root:root 0755 0755
+/etc/services.d/nordvpn/data/check false root:root 0755 0755

--- a/rootfs/etc/fix-attrs.d/nord_utils
+++ b/rootfs/etc/fix-attrs.d/nord_utils
@@ -3,4 +3,3 @@
 /usr/bin/nord_login false root:root 0755 0755
 /usr/bin/nord_migrate false root:root 0755 0755
 /usr/bin/nord_watch false root:root 0755 0755
-/etc/services.d/nordvpn/data/check false root:root 0755 0755

--- a/rootfs/etc/fix-attrs.d/s6
+++ b/rootfs/etc/fix-attrs.d/s6
@@ -1,0 +1,1 @@
+/etc/services.d/nordvpn/data/check false root:root 0755 0755

--- a/rootfs/usr/bin/nord_login
+++ b/rootfs/usr/bin/nord_login
@@ -13,6 +13,7 @@ if ! iptables -L > /dev/null 2>&1; then
     sleep 3600
   done
 fi
+sleep 5
 
 [[ -z "${PASS}" ]] && [[ -f "${PASSFILE}" ]] && PASS="$(head -n 1 "${PASSFILE}")"
 nordvpn logout > /dev/null


### PR DESCRIPTION
fixes #389 

upgraded OS to jammy
upgraded nord version to 3.16.1
fixed s6 permissions for check
added sleep to stop race condition for nordvpnd.sock