### PR TITLE
Stop invalidating my tokens

### DIFF
--- a/rootfs/usr/bin/nord_login
+++ b/rootfs/usr/bin/nord_login
@@ -16,7 +16,7 @@ fi
 sleep 5
 
 [[ -z "${PASS}" ]] && [[ -f "${PASSFILE}" ]] && PASS="$(head -n 1 "${PASSFILE}")"
-nordvpn logout > /dev/null
+nordvpn logout --persist-token > /dev/null
 
 if [[ -n ${TOKEN} ]]; then
   nordvpn login --token "${TOKEN}" || {


### PR DESCRIPTION
Ideally this would be opt-in, but in the interest of preserving the previous behavior I am adding this.
I found that restarting the container would invalidate my token, removing it from the account.
A search revealed this was a product of an intentional change: https://github.com/NordSecurity/nordvpn-linux/issues/8
Tested and working after stopping, restarting, and recreating the container.