### PR TITLE
Update Nordvpn CLI to 3.16.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy
 LABEL maintainer="Julio Gutierrez julio.guti+nordvpn@pm.me"
 
-ARG NORDVPN_VERSION=3.16.1
+ARG NORDVPN_VERSION=3.16.2
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \

--- a/README.md
+++ b/README.md
@@ -174,10 +174,8 @@ services:
 
 # ENVIRONMENT VARIABLES
 
-* `USER`     - DEPRECATED. User for NordVPN account.
-* `PASS`     - DEPRECATED. Password for NordVPN account, surrounding the password in single quotes will prevent issues with special characters such as `$`.
-* `TOKEN`    - Used in place of `USER` and `PASS` for NordVPN account, can be generated in the web portal
-* `PASSFILE` - File from which to get `PASS`, if using [docker secrets](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets) this should be set to `/run/secrets/<secret_name>`. This file should contain just the account password on the first line.
+* `TOKEN`    - Token for NordVPN account, can be generated in the web portal
+* `TOKENFILE` - File from which to get `TOKEN`, if using [docker secrets](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets) this should be set to `/run/secrets/<secret_name>`. Thi
 * `CONNECT`  -  [country]/[server]/[country_code]/[city]/[group] or [country] [city], if none provide you will connect to  the recommended server.
    - Provide a [country] argument to connect to a specific country. For example: Australia , Use `docker run --rm ghcr.io/bubuntux/nordvpn nordvpn countries` to get the list of countries.
    - Provide a [server] argument to connect to a specific server. For example: jp35 , [Full List](https://nordvpn.com/servers/tools/)

--- a/rootfs/usr/bin/nord_login
+++ b/rootfs/usr/bin/nord_login
@@ -15,7 +15,7 @@ if ! iptables -L > /dev/null 2>&1; then
 fi
 sleep 5
 
-[[ -z "${PASS}" ]] && [[ -f "${PASSFILE}" ]] && PASS="$(head -n 1 "${PASSFILE}")"
+[[ -z "${TOKEN}" ]] && [[ -f "${TOKENFILE}" ]] && TOKEN="$(head -n 1 "${TOKENFILE}")"
 nordvpn logout --persist-token > /dev/null
 
 if [[ -n ${TOKEN} ]]; then
@@ -24,10 +24,8 @@ if [[ -n ${TOKEN} ]]; then
     exit 1
   }
 else
-  nordvpn login --legacy --username "${USER}" --password "${PASS}" || {
-    echo "Invalid Username or password."
-    exit 1
-  }
+  echo "No token set."
+  exit 1
 fi
 
 exit 0


### PR DESCRIPTION
‼️ Breaking Change: Nord removed the ability to login with user/password, and now forces users to use a Token. [See changelog](https://nordvpn.com/blog/nordvpn-linux-release-notes/).

This PR does the following:
- Update CLI to 3.16.2
- Remove `$USER`, `$PASS`, and `$PASSFILE`
- Add `$TOKENFILE`

Kinda ugly that they pushed a breaking change in a patch version but hey…

The tag for this version should either be 3.16.2 or 4.0 depending on whether we want to match the CLI version or not (seems like we used to be 1:1 with Nord until 3.12, but we're not anymore).