### PR TITLE
Fixes for iptables, nordvpn.sock, and nordvpn settings

### DIFF
--- a/rootfs/etc/cont-init.d/00-firewall
+++ b/rootfs/etc/cont-init.d/00-firewall
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+update-alternatives --set iptables /usr/sbin/iptables-legacy
+update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
 iptables -P OUTPUT DROP
 iptables -P INPUT DROP
 iptables -P FORWARD DROP

--- a/rootfs/etc/services.d/nordvpn/run
+++ b/rootfs/etc/services.d/nordvpn/run
@@ -4,4 +4,4 @@ if [[ ! -d /run/nordvpn ]]; then
   mkdir -m 0770 /run/nordvpn
 fi
 
-exec s6-notifyoncheck -d /usr/sbin/nordvpnd > /dev/null
+exec s6-notifyoncheck -n 60 -d /usr/sbin/nordvpnd > /dev/null

--- a/rootfs/usr/bin/nord_config
+++ b/rootfs/usr/bin/nord_config
@@ -1,5 +1,7 @@
 #!/usr/bin/with-contenv bash
 
+nordvpn set technology ${TECHNOLOGY:-NordLynx}
+
 [[ -n ${DNS} ]] && nordvpn set dns ${DNS//[;,]/ }
 
 [[ -n ${CYBER_SEC} ]] && nordvpn set cybersec ${CYBER_SEC}
@@ -8,7 +10,6 @@
 #[[ -n ${KILLSWITCH} ]] && nordvpn set killswitch ${KILLSWITCH} Killswitch is enabled by default using iptables
 
 [[ -n ${PROTOCOL} ]] && nordvpn set protocol ${PROTOCOL}
-nordvpn set technology ${TECHNOLOGY:-NordLynx}
 
 [[ -n ${PORTS} ]] && for port in ${PORTS//[;,]/ }; do nordvpn whitelist add port "${port}"; done
 [[ -n ${PORT_RANGE} ]] && nordvpn whitelist add ports ${PORT_RANGE}

--- a/rootfs/usr/bin/nord_login
+++ b/rootfs/usr/bin/nord_login
@@ -13,7 +13,10 @@ if ! iptables -L > /dev/null 2>&1; then
     sleep 3600
   done
 fi
-sleep 5
+
+while [ ! -S /run/nordvpn/nordvpnd.sock ] ; do
+  sleep 1
+done
 
 [[ -z "${PASS}" ]] && [[ -f "${PASSFILE}" ]] && PASS="$(head -n 1 "${PASSFILE}")"
 nordvpn logout --persist-token > /dev/null


### PR DESCRIPTION
This PR solves 3 bugs:

1. `FATAL: iptables is not functional. Ensure your container config adds --cap-add=NET_ADMIN,NET_RAW`
This is solved by adding `update-alternatives --set iptables /usr/sbin/iptables-legacy`

2. nordvpn.sock not existing
On my (slow) server, it takes 20-30 seconds for the nordvpn.sock to appear.  Existing code exits long before that is reached.
This is solved by having s6-notifyoncheck try for up to 60 seconds to let nordvpnd create the socket, and also by having the nordvpn login wait pending the existence of the socket.

3. nordvpn settings like using TCP were not getting applied
This is solved by setting the technology first, because it is an error to change certain settings without doing that first.
