### PR TITLE
upgrade ubuntu packages (ssl, ca-certs, etc) and install latest nordvpn by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
 FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy
 LABEL maintainer="Julio Gutierrez julio.guti+nordvpn@pm.me"
 
-ARG NORDVPN_VERSION=3.16.5
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -y && \
+RUN apt-get update -y && apt-get upgrade -y && \
     apt-get install -y curl iputils-ping libc6 wireguard && \
     curl https://repo.nordvpn.com/deb/nordvpn/debian/pool/main/nordvpn-release_1.0.0_all.deb --output /tmp/nordrepo.deb && \
     apt-get install -y /tmp/nordrepo.deb && \
     apt-get update -y && \
-    apt-get install -y nordvpn${NORDVPN_VERSION:+=$NORDVPN_VERSION} && \
+    apt-get install -y nordvpn && \
     apt-get remove -y nordvpn-release && \
     apt-get autoremove -y && \
     apt-get autoclean -y && \


### PR DESCRIPTION
What do you think? You may not want to run `apt upgrade` but I see no point for nordvpn version, whoever will build docker from your docker file, would like latest anyway, no?