### PR TITLE
Update NordVPN Client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy
 LABEL maintainer="Julio Gutierrez julio.guti+nordvpn@pm.me"
 
-ARG NORDVPN_VERSION=3.17.4
+ARG NORDVPN_VERSION=3.19.0
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \


### PR DESCRIPTION
This pull request includes an update to the `Dockerfile` to use a newer version of NordVPN.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L4-R4): Updated the `NORDVPN_VERSION` argument from `3.17.4` to `3.19.0`.

I am not sure if it requires testing or what, but if we can bump the version of the NordVPN client, maybe it's a good time to do so as there are numerous improvements and bug fixes in the latest version.