### PR TITLE
Update Dockerfile and README for NordVPN version 4.0.0 and ubuntu 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy
+FROM ghcr.io/linuxserver/baseimage-ubuntu:noble
 LABEL maintainer="Julio Gutierrez julio.guti+nordvpn@pm.me"
 
-ARG NORDVPN_VERSION=3.20.0
+ARG NORDVPN_VERSION=4.0.0
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
@@ -20,5 +20,8 @@ RUN apt-get update -y && \
 		/var/tmp/*
 
 COPY /rootfs /
+RUN chmod +x /etc/cont-init.d/* /etc/services.d/nordvpn/* \
+    /usr/bin/dockerNetworks /usr/bin/dockerNetworks6 /usr/bin/nord_config /usr/bin/nord_connect /usr/bin/nord_login /usr/bin/nord_migrate /usr/bin/nord_watch \
+    /etc/services.d/nordvpn/data/check
 ENV S6_CMD_WAIT_FOR_SERVICES=1
 CMD nord_login && nord_config && nord_connect && nord_migrate && nord_watch

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ services:
 # ENVIRONMENT VARIABLES
 
 * `TOKEN`    - Token for NordVPN account, can be generated in the web portal
-* `TOKENFILE` - File from which to get `TOKEN`, if using [docker secrets](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets) this should be set to `/run/secrets/<secret_name>`. Thi
+* `TOKENFILE` - File from which to get `TOKEN`, if using [docker secrets](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets) this should be set to `/run/secrets/<secret_name>`. This takes precedence over `TOKEN`.
 * `CONNECT`  -  [country]/[server]/[country_code]/[city]/[group] or [country] [city], if none provide you will connect to  the recommended server.
    - Provide a [country] argument to connect to a specific country. For example: Australia , Use `docker run --rm ghcr.io/bubuntux/nordvpn nordvpn countries` to get the list of countries.
    - Provide a [server] argument to connect to a specific server. For example: jp35 , [Full List](https://nordvpn.com/servers/tools/)


### PR DESCRIPTION
Upgrade base image from Ubuntu Jammy (22.04) to Noble (24.04)
Update NordVPN client from version 3.20.0 to 4.0.0
Add explicit chmod to ensure executable permissions for init scripts and utility binaries
Complete sentence in the README.md