### PR TITLE
Update Docker base image to lscr.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:noble
+FROM lscr.io/linuxserver/baseimage-ubuntu:noble
 LABEL maintainer="Julio Gutierrez julio.guti+nordvpn@pm.me"
 
 ARG NORDVPN_VERSION=4.1.1


### PR DESCRIPTION
It looks like linuxserver base images have a different address now.